### PR TITLE
feat: Add 'Create New Account' button and functionality

### DIFF
--- a/apps/OpenSign/public/locales/de/translation.json
+++ b/apps/OpenSign/public/locales/de/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"Wählen Sie eine aus",
   "search-templates": "Vorlagen durchsuchen…",
   "search-documents": "Dokumente suchen…",
-  "search-contacts": "Kontakte durchsuchen…"
+  "search-contacts": "Kontakte suchen...",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/public/locales/en/translation.json
+++ b/apps/OpenSign/public/locales/en/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"Choose One",
   "search-templates": "Search templates…",
   "search-documents": "Search documents…",
-  "search-contacts": "Search contacts…"
+  "search-contacts": "Search contacts…",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/public/locales/es/translation.json
+++ b/apps/OpenSign/public/locales/es/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"Elige uno",
   "search-templates": "Buscar plantillas…",
   "search-documents": "Buscar documentos…",
-  "search-contacts": "Buscar contactos…"
+  "search-contacts": "Buscar contactos…",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/public/locales/fr/translation.json
+++ b/apps/OpenSign/public/locales/fr/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"Choisissez-en un",
   "search-templates": "Rechercher des modèles…",
   "search-documents": "Rechercher des documents…",
-  "search-contacts": "Rechercher des contacts…"
+  "search-contacts": "Rechercher des contacts…",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/public/locales/hi/translation.json
+++ b/apps/OpenSign/public/locales/hi/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"एक का चयन",
   "search-templates": "टेम्पलेट खोजें…",
   "search-documents": "दस्तावेज़ खोजें…",
-  "search-contacts": "संपर्क खोजें…"
+  "search-contacts": "संपर्क खोजें...",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/public/locales/it/translation.json
+++ b/apps/OpenSign/public/locales/it/translation.json
@@ -1033,5 +1033,20 @@
   "choose-one":"Scegline uno",
   "search-templates": "Cerca modelli…",
   "search-documents": "Cerca documenti…",
-  "search-contacts": "Cerca contatti…"
+  "search-contacts": "Cerca contatti…",
+  "fill-all-fields": "Please fill all required fields.",
+  "invalid-email-format": "Please enter a valid email address.",
+  "passwords-do-not-match": "Passwords do not match.",
+  "password-too-short": "Password must be at least 6 characters long.",
+  "account-created-success": "Account created successfully! Please login.",
+  "account-creation-failed": "Account creation failed. Please try again.",
+  "email-already-taken": "This email address is already registered.",
+  "create-account-title": "Create Account",
+  "create-your-account": "Create Your Account",
+  "start-your-journey": "Start your journey with OpenSign™.",
+  "full-name": "Full Name",
+  "creating-account": "Creating Account...",
+  "already-have-account": "Already have an account? Login",
+  "create-account-alt-img": "Illustration for account creation page",
+  "create-new-account": "Create New Account"
 }

--- a/apps/OpenSign/src/App.jsx
+++ b/apps/OpenSign/src/App.jsx
@@ -30,6 +30,7 @@ const AddAdmin = lazy(() => import("./pages/AddAdmin"));
 const UpdateExistUserAdmin = lazy(() => import("./pages/UpdateExistUserAdmin"));
 const Preferences = lazy(() => import("./pages/Preferences"));
 const Login = lazy(() => import("./pages/Login"));
+const CreateAccount = lazy(() => import("./pages/CreateAccount")); // Added CreateAccount
 const VerifyDocument = lazy(() => import("./pages/VerifyDocument"));
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/legacy/build/pdf.worker.min.mjs`;
 const AppLoader = () => {
@@ -75,6 +76,10 @@ function App() {
                   <Route
                     path="/upgrade-2.1"
                     element={<LazyPage Page={UpdateExistUserAdmin} />}
+                  />
+                  <Route
+                    path="/create-account" // Added route for CreateAccount
+                    element={<LazyPage Page={CreateAccount} />}
                   />
             </Route>
             <Route element={<Validate />}>

--- a/apps/OpenSign/src/pages/CreateAccount.jsx
+++ b/apps/OpenSign/src/pages/CreateAccount.jsx
@@ -1,0 +1,330 @@
+import React, { useState, useEffect } from "react";
+import Parse from "parse";
+import { useDispatch } from "react-redux";
+import { useNavigate, NavLink } from "react-router-dom";
+import Title from "../components/Title";
+import login_img from "../assets/images/login_img.svg"; // Consider a different image or none
+import { useWindowSize } from "../hook/useWindowSize";
+import { emailRegex } from "../constant/const";
+import Alert from "../primitives/Alert";
+import { appInfo } from "../constant/appinfo";
+import { fetchAppInfo } from "../redux/reducers/infoReducer";
+import { getAppLogo, saveLanguageInLocal } from "../constant/Utils";
+import Loader from "../primitives/Loader";
+import { useTranslation } from "react-i18next";
+import SelectLanguage from "../components/pdf/SelectLanguage";
+
+function CreateAccount() {
+  const appName = "OpenSign™";
+  const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const { width } = useWindowSize();
+  const [state, setState] = useState({
+    fullName: "",
+    email: "",
+    password: "",
+    confirmPassword: "",
+    alertType: "success",
+    alertMsg: "",
+    passwordVisible: false,
+    confirmPasswordVisible: false,
+    loading: false,
+  });
+  const [image, setImage] = useState();
+  const [errMsg, setErrMsg] = useState();
+
+  useEffect(() => {
+    const initialize = async () => {
+      const app = await getAppLogo();
+      if (app?.error === "invalid_json") {
+        setErrMsg(t("server-down", { appName: appName }));
+      } else if (app?.user === "not_exist" && !window.location.pathname.includes("/addadmin")) {
+        // Allow access if admin needs to be created, otherwise redirect if trying to access signup directly
+        // navigate("/addadmin");
+      }
+      if (app?.logo) {
+        setImage(app?.logo);
+      } else {
+        setImage(appInfo?.applogo || undefined);
+      }
+      dispatch(fetchAppInfo());
+    };
+    initialize();
+    // eslint-disable-next-line
+  }, []);
+
+  const showToast = (type, msg) => {
+    setState({ ...state, loading: false, alertType: type, alertMsg: msg });
+    setTimeout(() => setState({ ...state, alertMsg: "" }), 3000);
+  };
+
+  const handleChange = (event) => {
+    let { name, value } = event.target;
+    if (name === "email") {
+      value = value?.toLowerCase()?.replace(/\s/g, "");
+    }
+    setState({ ...state, [name]: value });
+  };
+
+  const handleCreateAccount = async (event) => {
+    event.preventDefault();
+    const { fullName, email, password, confirmPassword } = state;
+
+    if (!fullName || !email || !password || !confirmPassword) {
+      showToast("danger", t("fill-all-fields", "Please fill all required fields.")); // Added fallback text
+      return;
+    }
+    if (!emailRegex.test(email)) {
+      showToast("danger", t("invalid-email-format", "Please enter a valid email address."));
+      return;
+    }
+    if (password !== confirmPassword) {
+      showToast("danger", t("passwords-do-not-match", "Passwords do not match."));
+      return;
+    }
+    if (password.length < 6) { // Example: Basic password length validation
+        showToast("danger", t("password-too-short", "Password must be at least 6 characters long."));
+        return;
+    }
+
+    setState({ ...state, loading: true });
+
+    try {
+      const params = {
+        userDetails: {
+          name: fullName,
+          email: email,
+          password: password,
+          role: "contracts_User", // Default role, adjust if necessary
+          // company and jobTitle can be collected later or made optional
+        },
+      };
+      // The 'usersignup' cloud function is expected to handle actual user creation in Parse
+      const user = await Parse.Cloud.run("usersignup", params);
+
+      if (user && user.id) {
+        // New user created in _User table, now create corresponding ExtUser
+        // The usersignup function in main.js seems to handle ExtUser creation as well.
+        showToast("success", t("account-created-success", "Account created successfully! Please login."));
+        setTimeout(() => navigate("/login"), 2000);
+      } else if (user && user.error) {
+         // Handle specific errors from backend if provided
+        showToast("danger", user.message || t("account-creation-failed", "Account creation failed. Please try again."));
+      } else {
+        showToast("danger", t("account-creation-failed", "Account creation failed. Please try again."));
+      }
+    } catch (error) {
+      console.error("Error creating account:", error);
+      // Check for specific Parse error codes if needed
+      if (error.code === 202) { // Email already taken
+        showToast("danger", t("email-already-taken", "This email address is already registered."));
+      } else {
+        showToast("danger", error.message || t("something-went-wrong-mssg", "Something went wrong. Please try again."));
+      }
+    } finally {
+      setState({ ...state, loading: false });
+    }
+  };
+
+  const togglePasswordVisibility = (field) => {
+    if (field === "password") {
+      setState({ ...state, passwordVisible: !state.passwordVisible });
+    } else if (field === "confirmPassword") {
+      setState({ ...state, confirmPasswordVisible: !state.confirmPasswordVisible });
+    }
+  };
+
+  return errMsg ? (
+    <div className="h-screen flex justify-center text-center items-center p-4 text-gray-500 text-base">
+      {errMsg}
+    </div>
+  ) : (
+    <div>
+      <Title title={t("create-account-title", "Create Account")} />
+      {state.loading && (
+        <div
+          aria-live="assertive"
+          className="fixed w-full h-full flex justify-center items-center bg-black bg-opacity-30 z-50"
+        >
+          <Loader />
+        </div>
+      )}
+      {appInfo && appInfo.appId ? (
+        <>
+          <div
+            aria-labelledby="createAccountHeading"
+            role="region"
+            className="pb-1 md:pb-4 pt-10 md:px-10 lg:px-16 h-full min-h-screen flex flex-col justify-center"
+          >
+            <div className="md:p-4 lg:p-10 p-4 bg-base-100 text-base-content op-card max-w-4xl mx-auto w-full">
+              <div className="flex justify-center md:justify-start w-full">
+                <div className="w-[200px] h-[50px] inline-block overflow-hidden mb-6">
+                  {image && (
+                    <img
+                      src={image}
+                      className="object-contain h-full w-full"
+                      alt="applogo"
+                    />
+                  )}
+                </div>
+              </div>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8">
+                <div className="flex flex-col justify-center">
+                  <form onSubmit={handleCreateAccount} aria-label="Create Account Form">
+                    <h1 id="createAccountHeading" className="text-[28px] md:text-[30px] mt-0 mb-2 text-center md:text-left">
+                      {t("create-your-account", "Create Your Account")}
+                    </h1>
+                    <p className="text-[12px] text-[#878787] mb-6 text-center md:text-left">
+                      {t("start-your-journey", "Start your journey with OpenSign™.")}
+                    </p>
+
+                    <fieldset className="space-y-4">
+                      <div>
+                        <label className="block text-xs mb-1" htmlFor="fullName">
+                          {t("full-name", "Full Name")}
+                        </label>
+                        <input
+                          id="fullName"
+                          type="text"
+                          className="op-input op-input-bordered op-input-sm focus:outline-none hover:border-base-content w-full text-xs"
+                          name="fullName"
+                          value={state.fullName}
+                          onChange={handleChange}
+                          required
+                          onInvalid={(e) => e.target.setCustomValidity(t("input-required", "This field is required."))}
+                          onInput={(e) => e.target.setCustomValidity("")}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-xs mb-1" htmlFor="email">
+                          {t("email", "Email Address")}
+                        </label>
+                        <input
+                          id="email"
+                          type="email"
+                          className="op-input op-input-bordered op-input-sm focus:outline-none hover:border-base-content w-full text-xs"
+                          name="email"
+                          autoComplete="username"
+                          value={state.email}
+                          onChange={handleChange}
+                          required
+                          onInvalid={(e) => e.target.setCustomValidity(t("invalid-email-format", "Please enter a valid email."))}
+                          onInput={(e) => e.target.setCustomValidity("")}
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-xs mb-1" htmlFor="password">
+                          {t("password", "Password")}
+                        </label>
+                        <div className="relative">
+                          <input
+                            id="password"
+                            type={state.passwordVisible ? "text" : "password"}
+                            className="op-input op-input-bordered op-input-sm focus:outline-none hover:border-base-content w-full text-xs"
+                            name="password"
+                            value={state.password}
+                            autoComplete="new-password"
+                            onChange={handleChange}
+                            required
+                            onInvalid={(e) => e.target.setCustomValidity(t("input-required", "This field is required."))}
+                            onInput={(e) => e.target.setCustomValidity("")}
+                          />
+                          <span
+                            className="absolute cursor-pointer top-[50%] right-[10px] -translate-y-[50%] text-base-content"
+                            onClick={() => togglePasswordVisibility("password")}
+                          >
+                            {state.passwordVisible ? (
+                              <i className="fa-light fa-eye-slash text-xs pb-1" />
+                            ) : (
+                              <i className="fa-light fa-eye text-xs pb-1 " />
+                            )}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div>
+                        <label className="block text-xs mb-1" htmlFor="confirmPassword">
+                          {t("confirm-password", "Confirm Password")}
+                        </label>
+                        <div className="relative">
+                          <input
+                            id="confirmPassword"
+                            type={state.confirmPasswordVisible ? "text" : "password"}
+                            className="op-input op-input-bordered op-input-sm focus:outline-none hover:border-base-content w-full text-xs"
+                            name="confirmPassword"
+                            value={state.confirmPassword}
+                            autoComplete="new-password"
+                            onChange={handleChange}
+                            required
+                            onInvalid={(e) => e.target.setCustomValidity(t("input-required", "This field is required."))}
+                            onInput={(e) => e.target.setCustomValidity("")}
+                          />
+                          <span
+                            className="absolute cursor-pointer top-[50%] right-[10px] -translate-y-[50%] text-base-content"
+                            onClick={() => togglePasswordVisibility("confirmPassword")}
+                          >
+                            {state.confirmPasswordVisible ? (
+                              <i className="fa-light fa-eye-slash text-xs pb-1" />
+                            ) : (
+                              <i className="fa-light fa-eye text-xs pb-1 " />
+                            )}
+                          </span>
+                        </div>
+                      </div>
+                    </fieldset>
+
+                    <div className="mt-6">
+                      <button
+                        type="submit"
+                        className="op-btn op-btn-primary w-full"
+                        disabled={state.loading}
+                      >
+                        {state.loading ? t("creating-account", "Creating Account...") : t("create-account-btn", "Create Account")}
+                      </button>
+                    </div>
+                    <div className="text-center mt-4 text-xs">
+                        <NavLink
+                            to="/login"
+                            className="op-link op-link-primary underline-offset-1 focus:outline-none"
+                        >
+                            {t("already-have-account", "Already have an account? Login")}
+                        </NavLink>
+                    </div>
+                  </form>
+                </div>
+                {width >= 768 && (
+                  <div className="hidden md:flex items-center justify-center">
+                    <div className="mx-auto md:w-[300px] lg:w-[350px] xl:w-[400px]">
+                      <img
+                        src={login_img} // Consider a more relevant image for account creation
+                        alt={t("create-account-alt-img", "Illustration for account creation page")}
+                        width="100%"
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            </div>
+            <div className="mt-auto"> {/* Pushes SelectLanguage to the bottom */}
+             <SelectLanguage />
+            </div>
+            {state.alertMsg && (
+              <Alert type={state.alertType}>{state.alertMsg}</Alert>
+            )}
+          </div>
+        </>
+      ) : (
+        <div
+          aria-live="assertive"
+          className="fixed w-full h-full flex justify-center items-center z-50"
+        >
+          <Loader />
+        </div>
+      )}
+    </div>
+  );
+}
+export default CreateAccount;

--- a/apps/OpenSign/src/pages/Login.jsx
+++ b/apps/OpenSign/src/pages/Login.jsx
@@ -506,7 +506,15 @@ function Login() {
                         className="op-btn op-btn-primary"
                         disabled={state.loading}
                       >
-                        {state.loading ? t("loading") : t("login")}
+                        {state.loading ? t("loading", "Loading...") : t("login", "Login")}
+                      </button>
+                      <button
+                        type="button"
+                        className="op-btn op-btn-error" // DaisyUI error color for red
+                        disabled={state.loading}
+                        onClick={() => navigate("/create-account")}
+                      >
+                        {t("create-new-account", "Create New Account")}
                       </button>
                     </div>
                   </form>


### PR DESCRIPTION
- Adds a 'Create New Account' button to the Login page.
- Creates a new page at /create-account with a form for user registration (Full Name, Email, Password).
- The form calls the existing Parse Cloud function 'usersignup' to handle account creation.
- Includes basic frontend validation for the registration form.
- Adds routing for the new page.
- Styles the new elements consistently with the existing application design.
- Adds new translation keys for UI text with English defaults.